### PR TITLE
Provide shrink as a public method

### DIFF
--- a/include/shelf-pack.hpp
+++ b/include/shelf-pack.hpp
@@ -216,21 +216,7 @@ public:
             }
         }
 
-        // Shrink the width/height of the sprite to the bare minimum.
-        // Since shelf-pack doubles first width, then height when running out of shelf space
-        // this can result in fairly large unused space both in width and height if that happens
-        // towards the end of bin packing.
-        if (shelves_.size()) {
-            int32_t w2 = 0;
-            int32_t h2 = 0;
-
-            for (auto& shelf : shelves_) {
-                h2 += shelf.h();
-                w2 = std::max(shelf.w() - shelf.wfree(), w2);
-            }
-
-            resize(w2, h2);
-        }
+        shrink();
 
         return results;
     }
@@ -351,6 +337,28 @@ public:
         }
 
         return nullptr;
+    }
+
+
+    /**
+     *
+     * Shrink the width/height of the sprite to the bare minimum.
+     * Since shelf-pack doubles first width, then height when running out of shelf space
+     * this can result in fairly large unused space both in width and height if that happens
+     * towards the end of bin packing.
+     */
+    void shrink() {
+        if (shelves_.size()) {
+            int32_t w2 = 0;
+            int32_t h2 = 0;
+
+            for (auto& shelf : shelves_) {
+                h2 += shelf.h();
+                w2 = std::max(shelf.w() - shelf.wfree(), w2);
+            }
+
+            resize(w2, h2);
+        }
     }
 
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -815,6 +815,23 @@ void testClear() {
     std::cout << " - OK" << std::endl;
 }
 
+void testShrink() {
+    std::cout << "shrink succeeds";
+
+    ShelfPack sprite(20, 20);
+    sprite.packOne(-1, 10, 5);
+
+    assert(sprite.width() == 20);
+    assert(sprite.height() == 20);
+
+    sprite.shrink();
+
+    assert(sprite.width() == 10);
+    assert(sprite.height() == 5);
+
+    std::cout << " - OK" << std::endl;
+}
+
 void testResize1() {
     std::cout << "resize larger succeeds";
 


### PR DESCRIPTION
This is useful when you have your own loop executing `packOne` a bunch of times, and you want to minimize space at the end. [Example](https://github.com/mapbox/mapbox-gl-native/blob/7ce6be3aa8f31e093756f248e175bee2c064f72b/src/mbgl/text/glyph_atlas.cpp#L16-L60).